### PR TITLE
Enable install via pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Pycharm
+.idea/

--- a/heapanalytics/consumer.py
+++ b/heapanalytics/consumer.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals
 
 """
 Consumers to send the data to Heap Analytics.

--- a/heapanalytics/exceptions.py
+++ b/heapanalytics/exceptions.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals
 
 """
 Heap Analytics Exceptions.

--- a/heapanalytics/heapanalytics.py
+++ b/heapanalytics/heapanalytics.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals
 
 """
 A module for using the HeapAnalytics Server-Side API (https://heapanalytics.com/docs/server-side)

--- a/heapanalytics/utils/__init__.py
+++ b/heapanalytics/utils/__init__.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals

--- a/heapanalytics/utils/json.py
+++ b/heapanalytics/utils/json.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals
 
 """
 Get the JSON implementation.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, find_packages
+from setuptools import setup, find_packages
 
 setup(
     name='heapanalytics-python',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
-from distutils.core import setup
+from distutils.core import setup, find_packages
 
 setup(
     name='heapanalytics-python',
     version='0.1',
-    packages=['heapanalytics'],
+    packages=find_packages(),
     license=open('LICENSE').read(),
     author='Michael Palumbo',
     author_email='michael.palumbo87@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='heapanalytics-python',
     version='0.1',
-    packages=[''],
+    packages=['heapanalytics'],
     license=open('LICENSE').read(),
     author='Michael Palumbo',
     author_email='michael.palumbo87@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from distutils.core import setup
+
+setup(
+    name='heapanalytics-python',
+    version='0.1',
+    packages=[''],
+    license=open('LICENSE').read(),
+    author='Michael Palumbo',
+    author_email='michael.palumbo87@gmail.com',
+    description='HeapAnalytics Python library for server-side integration.'
+    long_description=open('README.md').read(),
+    keywords='heap analytics python',
+)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license=open('LICENSE').read(),
     author='Michael Palumbo',
     author_email='michael.palumbo87@gmail.com',
-    description='HeapAnalytics Python library for server-side integration.'
+    description='HeapAnalytics Python library for server-side integration.',
     long_description=open('README.md').read(),
     keywords='heap analytics python',
 )


### PR DESCRIPTION
Configured setup.py to enable as a pip package. 
Removed some superfluous imports that are no longer needed in python2.7
